### PR TITLE
Update entrypoint.sh to not lose existing environment.properties in results

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ echo "\"buildName\":\"GitHub Actions Run #${INPUT_GITHUB_RUN_ID}\",\"buildOrder\
 mv ./executor.json ./${INPUT_ALLURE_RESULTS}
 
 #environment.properties
-echo "URL=${GITHUB_PAGES_WEBSITE_URL}" > environment.properties
+echo "GITHUB_PAGES_URL=${GITHUB_PAGES_WEBSITE_URL}" >> environment.properties
 mv ./environment.properties ./${INPUT_ALLURE_RESULTS}
 
 echo "keep allure history from ${INPUT_ALLURE_HISTORY}/last-history to ${INPUT_ALLURE_RESULTS}/history"


### PR DESCRIPTION
Allure results may already have environment.properties file generated by the tests run, and the URL property of some tested application.
Changed 'echo >' into  'echo >>' to append Github Pages URL property without overriding the whole content of environment.properties file.