### PR TITLE
Update environment.properties to append line instead of create new file

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,7 +49,7 @@ echo "\"buildName\":\"GitHub Actions Run #${INPUT_GITHUB_RUN_ID}\",\"buildOrder\
 mv ./executor.json ./${INPUT_ALLURE_RESULTS}
 
 #environment.properties
-echo "URL=${GITHUB_PAGES_WEBSITE_URL}" > environment.properties
+echo "URL=${GITHUB_PAGES_WEBSITE_URL}" >> environment.properties
 mv ./environment.properties ./${INPUT_ALLURE_RESULTS}
 
 echo "keep allure history from ${INPUT_GH_PAGES}/last-history to ${INPUT_ALLURE_RESULTS}/history"


### PR DESCRIPTION
I think that there is a bug.
I create an environment.properties in my repo, run the action and only URL is prompted in the report.
Most probably is because the file gets generated with the only URL, 
Changing it to '>>' will have the same behavior, create if empty and append if already exist.
Thanks!