### PR TITLE
Update script to retain CNAME file

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,7 +35,7 @@ if (( COUNT > INPUT_KEEP_REPORTS )); then
   echo "remove index.html last-history"
   rm index.html last-history -rv
   echo "remove old reports"
-  ls | sort -n | head -n -$((${INPUT_KEEP_REPORTS}-2)) | xargs rm -rv;
+  ls | sort -n | grep -v 'CNAME' | head -n -$((${INPUT_KEEP_REPORTS}-2)) | xargs rm -rv;
   cd ${GITHUB_WORKSPACE}
 fi
 


### PR DESCRIPTION
The [existing `entrypoint.sh` script](https://github.com/simple-elf/allure-report-action/blob/eca283b643d577c69b8e4f048dd6cd8eb8457cfd/entrypoint.sh#L38) removes historical builds, which also removes the `CNAME` file created by setting a custom domain name in GitHub Pages settings. Added `grep -v 'CNAME'` to remove that filename (if it exists) from the file list pipe.

Local shell testing verifies it works. I prepared an empty directory with:
```shell
touch 1
touch 2
touch 5
touch 10
touch CNAME
```

Here is the result of the original code:
```shell
> ls
1  10  2  5  CNAME
> ls | sort -n
CNAME
1
2
5
10
> ls | sort -n | head -n -2
CNAME
1
2
> ls | sort -n | head -n -2 | xargs rm -rv
removed 'CNAME'
removed '1'
removed '2'
> ls
10  5
```

Here is the updated code with `grep -v 'CNAME'` in the pipe:
```shell
> ls
1  10  2  5  CNAME
> ls | sort -n | grep -v 'CNAME' | head -n -2 | xargs rm -rv
removed '1'
removed '2'
> ls
10  5  CNAME
```

Here is the updated code but `CNAME` file does not exist, showing that this change is non-breaking:
```shell
> ls
1  10  2  5
> ls | sort -n | grep -v 'CNAME' | head -n -2 | xargs rm -rv
removed '1'
removed '2'
> ls
10  5
```

I have also run Actions against my company's private repo pointed at my change branch and the `CNAME` file is no longer being deleted.