### PR TITLE
Fix workflow url when hosted remotely

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@ Default ``
     allure_history: allure-history
 ```
 
+## Example usage (build to publish on different repo)
+
+```yaml
+- name: Test here and host elsewhere
+  uses: simple-elf/allure-report-action@master
+  if: always()
+  id: allure-report
+  with:
+    allure_results: build/allure-results
+    gh_pages: gh-pages
+    allure_report: allure-report
+    allure_history: allure-history
+    github_repo: your-org/allure-reports-host-server
+    github_repo_owner: your-org
+```
+
 ## Finally you need to publish on GitHub Pages
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,10 @@ inputs:
     description: 'GitHub repository owner'
     required: true
     default: ${{ github.repository_owner }}
+  github_tests_repo:
+    description: 'GitHub repository where test are run'
+    required: true
+    default: ${{ github.repository }}
   report_url:
     description: 'Use a custom URL instead of *.github.io'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,7 +48,7 @@ echo "<meta http-equiv=\"Pragma\" content=\"no-cache\"><meta http-equiv=\"Expire
 echo '{"name":"GitHub Actions","type":"github","reportName":"Allure Report with history",' > executor.json
 echo "\"url\":\"${GITHUB_PAGES_WEBSITE_URL}\"," >> executor.json # ???
 echo "\"reportUrl\":\"${GITHUB_PAGES_WEBSITE_URL}/${INPUT_GITHUB_RUN_NUM}/\"," >> executor.json
-echo "\"buildUrl\":\"${INPUT_GITHUB_SERVER_URL}/${INPUT_GITHUB_REPO}/actions/runs/${INPUT_GITHUB_RUN_ID}\"," >> executor.json
+echo "\"buildUrl\":\"${INPUT_GITHUB_SERVER_URL}/${INPUT_GITHUB_TESTS_REPO}/actions/runs/${INPUT_GITHUB_RUN_ID}\"," >> executor.json
 echo "\"buildName\":\"GitHub Actions Run #${INPUT_GITHUB_RUN_ID}\",\"buildOrder\":\"${INPUT_GITHUB_RUN_NUM}\"}" >> executor.json
 #cat executor.json
 mv ./executor.json ./${INPUT_ALLURE_RESULTS}


### PR DESCRIPTION
When building for GitHub Pages hosting on a different repository, the
GitHub repo address needs to point to where the tests were run.

Add a `github_tests_repo` input that defaults to repository on which the action is run, instead of mapping to the `github_repo`
input. This should work automatically when a different host repo is used, and allow customization for any other needs.

An example of hosting remotely was also added to the README file.

Resolves #56
Resolves #55