### PR TITLE
Remove trailing slash in the executor.json reportUrl

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,7 +48,7 @@ echo "<meta http-equiv=\"Pragma\" content=\"no-cache\"><meta http-equiv=\"Expire
 [ -z "$INPUT_REPORT_NAME" ] && INPUT_REPORT_NAME="Allure Report with history"
 echo '{"name":"GitHub Actions","type":"github","reportName":"'"$INPUT_REPORT_NAME"'",' > executor.json
 echo "\"url\":\"${GITHUB_PAGES_WEBSITE_URL}\"," >> executor.json # ???
-echo "\"reportUrl\":\"${GITHUB_PAGES_WEBSITE_URL}/${INPUT_GITHUB_RUN_NUM}/\"," >> executor.json
+echo "\"reportUrl\":\"${GITHUB_PAGES_WEBSITE_URL}/${INPUT_GITHUB_RUN_NUM}\"," >> executor.json
 echo "\"buildUrl\":\"${INPUT_GITHUB_SERVER_URL}/${INPUT_GITHUB_TESTS_REPO}/actions/runs/${INPUT_GITHUB_RUN_ID}\"," >> executor.json
 echo "\"buildName\":\"GitHub Actions Run #${INPUT_GITHUB_RUN_ID}\",\"buildOrder\":\"${INPUT_GITHUB_RUN_NUM}\"}" >> executor.json
 #cat executor.json


### PR DESCRIPTION
## What

This PR removes the trailing slash at the end of the `reportUrl` fed into `executor.json`.

## Why

We host our Allure reports on an S3 bucket and use a nested "folder" structure to include the test branch and run type. Since S3 does not support real folders, enabling the website hosting setting causes it to look for an `index.html` file near the last "folder" (aka slash).

For example, consider these inputs:
```
    report_url: http://<bucket-name>.s3-website-<region>.amazonaws.com/reports/<branch>/<github_run_id>
    github_run_num: 25354
    github_run_id: 16053251959
```

With S3 hosting, the report is accessible at:
`http://<bucket-name>.s3-website-<region>.amazonaws.com/reports/<branch>/<github_run_id>/index.html`

Visiting:
`http://<bucket-name>.s3-website-<region>.amazonaws.com/reports/<branch>/<github_run_id>` (or with a trailing slash)
`http://<bucket-name>.s3-website-<region>.amazonaws.com/reports/<branch>/<github_run_id>/`
will show the report fine.

However, a URL with a double slash at the end, like:
`http://<bucket-name>.s3-website-<region>.amazonaws.com/reports/<branch>/<github_run_id>/<github_run_num>//` results in a 404 error.

Before this PR, the History Trend included links to reports with an extra slash, which caused all reports accessed through the History Graph to return 404 when hosted on S3.

This PR fixes that issue.